### PR TITLE
Takes care of multiple users using same mac

### DIFF
--- a/toggleAirport.sh
+++ b/toggleAirport.sh
@@ -2,9 +2,15 @@
 #git@github.com:paulbhart/toggleairport.git
 #originally from https://gist.github.com/albertbori/1798d88a93175b9da00b
 
+tmp_dir="$HOME/tmp"
+
+if [ ! -d "$tmp_dir" ]; then
+  mkdir -p $tmp_dir
+fi
+
 # rate limiting, run at most every second
-if [ -f "/var/tmp/prev_toggle_airport_run" ]; then
-    prev_toggle_airport_run=`cat /var/tmp/prev_toggle_airport_run`
+if [ -f "$tmp_dir/prev_toggle_airport_run" ]; then
+    prev_toggle_airport_run=`cat $tmp_dir/prev_toggle_airport_run`
     prev_toggle_airport_run_po=$(($prev_toggle_airport_run + 1))
     current=`date +%s`
 
@@ -13,7 +19,7 @@ if [ -f "/var/tmp/prev_toggle_airport_run" ]; then
     fi
 fi
 
-date +%s > /var/tmp/prev_toggle_airport_run
+date +%s > $tmp_dir/prev_toggle_airport_run
 
 function set_airport {
 
@@ -21,11 +27,11 @@ function set_airport {
 
     if [ $new_status = "On" ]; then
         /usr/sbin/networksetup -setairportpower $air_name on
-        touch /var/tmp/prev_air_on
+        touch $tmp_dir/prev_air_on
     else
         /usr/sbin/networksetup -setairportpower $air_name off
-        if [ -f "/var/tmp/prev_air_on" ]; then
-            rm /var/tmp/prev_air_on
+        if [ -f "$tmp_dir/prev_air_on" ]; then
+            rm $tmp_dir/prev_air_on
         fi
     fi
 
@@ -46,13 +52,13 @@ air_name=`networksetup -listnetworkserviceorder | sed -En 's/^\(Hardware Port: (
 
 # Determine previous ethernet status
 # If file prev_eth_on exists, ethernet was active last time we checked
-if [ -f "/var/tmp/prev_eth_on" ]; then
+if [ -f "$tmp_dir/prev_eth_on" ]; then
     prev_eth_status="On"
 fi
 
 # Determine same for Wi-Fi status
 # File is prev_air_on
-if [ -f "/var/tmp/prev_air_on" ]; then
+if [ -f "$tmp_dir/prev_air_on" ]; then
     prev_air_status="On"
 fi
 
@@ -84,23 +90,16 @@ else
     # If so it was done manually by user
     if [ "$prev_air_status" != "$air_status" ]; then
         set_airport $air_status
-
-        # if [ "$air_status" = "On" ]; then
-        #     notify "Wi-Fi manually turned on."
-        # else
-        #     notify "Wi-Fi manually turned off."
-        # fi
-
     fi
 
 fi
 
 # Update ethernet status
 if [ "$eth_status" == "On" ]; then
-    touch /var/tmp/prev_eth_on
+    touch $tmp_dir/prev_eth_on
 else
-    if [ -f "/var/tmp/prev_eth_on" ]; then
-        rm /var/tmp/prev_eth_on
+    if [ -f "$tmp_dir/prev_eth_on" ]; then
+        rm $tmp_dir/prev_eth_on
     fi
 fi
 


### PR DESCRIPTION
I've found one bug, which happens when you run the toggleairport as one user and then try to use it as another, files in /var/tmp/ are not overwritten (access denied error). 

This change moves temp directory to user home, fixing this conflict. 