### PR TITLE
Suppressed the error message of ifconfig

### DIFF
--- a/toggleAirport.sh
+++ b/toggleAirport.sh
@@ -58,7 +58,7 @@ fi
 
 # Check actual current ethernet status
 for eth_name in ${eth_names}; do
-    if ([ "$eth_name" != "" ] && [ "`ifconfig $eth_name | grep "status: active"`" != "" ]); then
+    if ([ "$eth_name" != "" ] && [ "`ifconfig $eth_name 2>/dev/null | grep "status: active"`" != "" ]); then
         eth_status="On"
     fi
 done


### PR DESCRIPTION
Suppressed the error message of ifconfig that was causing the loop to break when ifconfig threw an error for interfaces that are disconnected. 